### PR TITLE
fix: make the `ParserStateResult` nullable

### DIFF
--- a/src/ParserState.ts
+++ b/src/ParserState.ts
@@ -3,7 +3,7 @@ import { ParserStateResult } from "./ParserStateResult";
 export type ParserState = {
   offset: number;
   input: string;
-  result: ParserStateResult;
+  result: ParserStateResult | null;
   isError: boolean;
   errorMessage?: string;
 };


### PR DESCRIPTION
Closes #138