### PR TITLE
fix: fix `anyOf` combinator returns wrong state when no parser can be matched

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%

--- a/src/combinators/anyOf.test.ts
+++ b/src/combinators/anyOf.test.ts
@@ -37,7 +37,7 @@ describe("anyOf", () => {
     expect(result).toStrictEqual<ParserState>({
       input: "Test",
       isError: true,
-      errorMessage: "Failed to match string Hello at offset 0",
+      errorMessage: "anyOf: unable to match any given parser",
       offset: 0,
       result: null,
     });

--- a/src/combinators/anyOf.ts
+++ b/src/combinators/anyOf.ts
@@ -1,5 +1,5 @@
 import { Parser } from "../Parser";
-import { ParserState, updateParserResult } from "../ParserState";
+import { ParserState, updateParserError, updateParserResult } from "../ParserState";
 
 /**
  * Tries to match all `parsers` and returns the first successful one.
@@ -7,7 +7,7 @@ import { ParserState, updateParserResult } from "../ParserState";
  */
 export const anyOf = (parsers: Array<Parser>) =>
   new Parser((state: ParserState): ParserState => {
-    let furthestState: ParserState = null;
+    if (state.isError) return state;
 
     for (const parser of parsers) {
       const currentState = parser.transformState(state);
@@ -15,11 +15,7 @@ export const anyOf = (parsers: Array<Parser>) =>
       if (!currentState.isError) {
         return updateParserResult(currentState, currentState.result);
       }
-
-      if (!furthestState || furthestState.offset < currentState.offset) {
-        furthestState = currentState;
-      }
     }
 
-    return updateParserResult(furthestState, furthestState.result);
+    return updateParserError(state, "anyOf: unable to match any given parser");
   });


### PR DESCRIPTION
Closes #150